### PR TITLE
fix rouing

### DIFF
--- a/app/views/communities/qa_show.html.erb
+++ b/app/views/communities/qa_show.html.erb
@@ -27,7 +27,7 @@
 
       <!-- 削除ボタンは管理者のみ表示 -->
       <!-- リンク先は後で変更する -->
-      <%= link_to '削除', communities_qa_show_path, class: 'btn btn-link' %>
+      <%= link_to '削除', community_qa_show_path, class: 'btn btn-link' %>
     </div>
     <div class="col-lg-4 offset-lg-7">
       <h5><span>ユーザー名</span><span>（解答者の名前を表示）</span></h5>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -20,7 +20,7 @@
 
      <!-- リンク先は後で変更 -->
     <div class="col-lg-1">
-      <%= link_to '詳細', items_show_path, class: 'btn btn-light' %>
+      <%= link_to '詳細', item_path(.id), class: 'btn btn-light' %>
     </div>
 
   </div>

--- a/app/views/shopping_cart/orders/new.html.erb
+++ b/app/views/shopping_cart/orders/new.html.erb
@@ -52,8 +52,8 @@
  <!-- 注文は銀行振込とクレジットで遷移先異なる -->
   <div class="row">
   	<div class="col-lg-4 offset-lg-10">
-      <%= link_to '戻る', shopping_carts_show_path, class: 'btn btn-light' %>
-      <%= link_to '注文', orders_show_path, class: 'btn btn-light' %>
+      <%= link_to '戻る', shopping_cart_show_path, class: 'btn btn-light' %>
+      <%= link_to '注文', orders_confirmation_path, class: 'btn btn-light' %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,10 +56,10 @@ Rails.application.routes.draw do
     post ':id', to: 'comments#add'
     delete ':id', to: 'comments#delete'
     # questions
-    get ':id/question', to: 'qustions#index', as: :question_index
-    delete ':id/question', to: 'qustions#delete'
-    get ':id/question/new', to: 'qustions#new', as: :question_new
-    post ':id/question/new', to: 'qustions#add'
+    get ':id/question', to: 'questions#index', as: :question_index
+    delete ':id/question', to: 'questions#delete'
+    get ':id/question/new', to: 'questions#new', as: :question_new
+    post ':id/question/new', to: 'questions#add'
     # answers
     post ':id/question/:question_id', to: 'answers#add'
     delete ':id/question/:question_id', to: 'answers#delete'


### PR DESCRIPTION
ルーティングの
# questions
get ':id/question', to: 'questions#index', as: :question_index
delete ':id/question', to: 'questions#delete'
get ':id/question/new', to: 'questions#new', as: :question_new
post ':id/question/new', to: 'questions#add'
部分を修正しました。
qustion　→　question